### PR TITLE
Removed `Boolean` type from config item

### DIFF
--- a/lib/fastlane/plugin/xchtmlreport/actions/xchtmlreport_action.rb
+++ b/lib/fastlane/plugin/xchtmlreport/actions/xchtmlreport_action.rb
@@ -91,7 +91,6 @@ module Fastlane
 
           FastlaneCore::ConfigItem.new(
             key: :enable_junit,
-            type: Boolean,
             default_value: false,
             description: "Enables JUnit XML output 'report.junit'",
             optional: true


### PR DESCRIPTION
Ruby does not have a Boolean type unless you add it in (c.f. https://stackoverflow.com/q/3028243). Therefore, having a ConfigItem with type: Boolean causes the following error NameError: uninitialized constant XchtmlreportAction::Boolean when using a new Ruby installation (e.g. if installed via homebrew).