### PR TITLE
Update readme - so scan failure doesn't stop lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ result_bundle(true)
 
 ```
 lane :tests do
-  scan
+  scan (
+  	fail_build: false # Otherwise following steps won't be executed
+  )
   xchtmlreport
 end
 ```


### PR DESCRIPTION
Updated README to make sure `xchtmlreport` is alwats run. 
`scan` command doesn't execute following steps if any tests fail, so `fail_build` must be set to `false`