### PR TITLE
Bundle path error when scan Is not called before report

### DIFF
--- a/lib/fastlane/plugin/xchtmlreport/actions/xchtmlreport_action.rb
+++ b/lib/fastlane/plugin/xchtmlreport/actions/xchtmlreport_action.rb
@@ -11,11 +11,15 @@ module Fastlane
         end
 
         result_bundle_path = params[:result_bundle_path]
+        result_bundle_paths = params[:result_bundle_paths]
         if result_bundle_path.nil?
-          result_bundle_path = Scan.cache[:result_bundle_path]
+          begin
+            result_bundle_path = Scan.cache[:result_bundle_path]
+          rescue Exception => exception
+            raise exception if result_bundle_paths.nil? || result_bundle_paths.empty?
+          end
         end
 
-        result_bundle_paths = params[:result_bundle_paths]
         if result_bundle_path && result_bundle_paths.empty?
           result_bundle_paths = [result_bundle_path]
         end


### PR DESCRIPTION
#11 
Ensure exception is only thrown when no path is provided for both bundle paths and bundle path
